### PR TITLE
sb_exists: drop use of faccessat

### DIFF
--- a/libsbutil/sb_exists.c
+++ b/libsbutil/sb_exists.c
@@ -10,15 +10,5 @@
 int sb_exists(int dirfd, const char *pathname, int flags)
 {
 	struct stat64 buf;
-
-	if (faccessat(dirfd, pathname, F_OK, flags) == 0)
-		return 0;
-
-	/* musl's faccessat gives EINVAL when the kernel does not support
-	 * faccessat2 and AT_SYMLINK_NOFOLLOW is set.
-	 * https://www.openwall.com/lists/musl/2023/06/19/1 */
-	if (errno != EINVAL)
-		return -1;
-
 	return fstatat64(dirfd, pathname, &buf, flags);
 }


### PR DESCRIPTION
faccessat appears to perform quite poorly under certain conditions. Go back to using fstatat until this can be debugged.

Bug: https://bugs.gentoo.org/910273