### PR TITLE
libsandbox: always permit access to '/memfd:'

### DIFF
--- a/libsandbox/libsandbox.c
+++ b/libsandbox/libsandbox.c
@@ -713,6 +713,12 @@ static int check_access(sbcontext_t *sbcontext, int sb_nr, const char *func,
 		/* Fall in a read/write denied path, Deny Access */
 		goto out;
 
+	if (!strncmp(resolv_path, "/memfd:", strlen("/memfd:"))) {
+		/* Allow operations on memfd objects #910561 */
+		result = 1;
+		goto out;
+	}
+
 	if (!sym_func) {
 		retval = check_prefixes(sbcontext->deny_prefixes,
 			sbcontext->num_deny_prefixes, resolv_path);


### PR DESCRIPTION
For memfd objects, the kernel populates the target for symlinks under /proc/$PID/fd as "/memfd:name". Said target does not actually exist.

It is unfortunate that the kernel includes the leading slash, but we will just have to work around it.

Bug: https://bugs.gentoo.org/910561