### PR TITLE
libsandbox: stat the original path for EEXIST hackaround

### DIFF
--- a/libsandbox/pre_check_mkdirat.c
+++ b/libsandbox/pre_check_mkdirat.c
@@ -37,7 +37,7 @@ bool sb_mkdirat_pre_check(const char *func, const char *pathname, int dirfd)
 	 * will trigger a sandbox violation.
 	 */
 	struct stat64 st;
-	if (0 == lstat64(canonic, &st)) {
+	if (0 == lstat64(pathname, &st)) {
 		int new_errno;
 		sb_debug_dyn("EARLY FAIL: %s(%s[%s]) @ lstat: %s\n",
 			func, pathname, canonic, strerror(errno));


### PR DESCRIPTION
Resolves an issue that can occur with paths that contain parent directory references (/../).

If part of the path does not exist, the sandboxed program should get ENOENT, not EEXIST. If we use the canonicalized path, intermediate paths will be eliminated and we produce the wrong result.

Bug: https://bugs.gentoo.org/921581