### PR TITLE
🐛 libsandbox: fix violations where ENOENT is expected

### DIFF
--- a/libsandbox/pre_check_mkdirat.c
+++ b/libsandbox/pre_check_mkdirat.c
@@ -37,15 +37,17 @@ bool sb_mkdirat_pre_check(const char *func, const char *pathname, int dirfd)
 	 * will trigger a sandbox violation.
 	 */
 	struct stat64 st;
-	if (0 == lstat64(pathname, &st)) {
+	if (0 == lstat64(canonic, &st)) {
 		int new_errno;
 		sb_debug_dyn("EARLY FAIL: %s(%s[%s]) @ lstat: %s\n",
 			func, pathname, canonic, strerror(errno));
 
 		new_errno = EEXIST;
 
-		/* Hmm, is this a broken symlink we're trying to extend ? */
-		if (S_ISLNK(st.st_mode) && stat64(pathname, &st) != 0) {
+		/* Hmm, is this a broken symlink we're trying to extend ?
+		 * Or is this a path like "foo/.." ?
+		 */
+		if (stat64(pathname, &st) != 0) {
 			/* XXX: This awful hack should probably be turned into a
 			 * common func that does a better job.  For now, we have
 			 * enough crap to catch gnulib tests #297026.

--- a/tests/mkdirat-3.sh
+++ b/tests/mkdirat-3.sh
@@ -4,4 +4,6 @@
 set -e
 mkdirat-0 -1,ENOENT .:O_DIRECTORY '' 0
 
+mkdirat-0 -1,ENOENT .:O_DIRECTORY 'foo/..' 0
+
 mkdirat-0 -1,ENOENT -3 '' 0


### PR DESCRIPTION
_Hello everyone,_

These changes revert f7d02c04 that aimed to resolve [921581](https://bugs.gentoo.org/921581) and fix it in a way that doesn't cause unwanted sandbox violations.

Currently, if you build `sandbox` from the `stable-2.x` branch, it may report violations while there shouldn't be any.

_To reproduce the issue, run:_
```bash
sandbox mkdir /foo/..
```

_Expected results:_
```
mkdir: cannot create directory ‘/foo/..’: No such file or directory
```

_Results for `stable-2.x` (truncated):_
```
 * ACCESS DENIED:  mkdir:              /
mkdir: cannot create directory ‘/foo/..’: Permission denied
```

_Results for `2.38`:_
```
mkdir: cannot create directory '/foo/..': File exists
```

Note: this fix might be cherry-picked to the `master` branch.

_Best regards!_