### PR TITLE
Rework LFS handing

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -25,12 +25,11 @@ AM_PROG_CC_C_O
 AC_ISC_POSIX
 AC_USE_SYSTEM_EXTENSIONS
 dnl http://www.gnu.org/s/libc/manual/html_node/Feature-Test-Macros.html
-dnl _LARGEFILE_SOURCE: enable support for new LFS funcs (ftello/etc...)
 dnl _LARGEFILE64_SOURCE: enable support for 64-bit variants (off64_t/fseeko64/etc...)
 dnl NB: We do not want -D_FILE_OFFSET_BITS=64 because we need to interpose both 32-bit
 dnl and 64-bit FS interfaces, and having the C library rewrite them makes that difficult.
 dnl Along those lines, we do not use AC_SYS_LARGEFILE.
-AS_VAR_APPEND([CPPFLAGS], [" -D_LARGEFILE_SOURCE -D_LARGEFILE64_SOURCE"])
+AS_VAR_APPEND([CPPFLAGS], [" -D_LARGEFILE64_SOURCE"])
 
 dnl Checks for programs.
 AM_PROG_AR

--- a/libsandbox/canonicalize.c
+++ b/libsandbox/canonicalize.c
@@ -92,14 +92,14 @@ erealpath(const char *name, char *resolved)
 		 * If not, try a little harder to consume this path in
 		 * case it has symlinks out into a better world ...
 		 */
-		struct stat64 st;
-		if (lstat64(rpath, &st) == -1 && errno == EACCES) {
+		struct stat st;
+		if (lstat(rpath, &st) == -1 && errno == EACCES) {
 			char *p = rpath;
 			strcpy(rpath, name);
 			do {
 				p = strchr(p, '/');
 				if (p) *p = '\0';
-				if (lstat64(rpath, &st))
+				if (lstat(rpath, &st))
 					break;
 				if (S_ISLNK(st.st_mode)) {
 					char buffer[SB_PATH_MAX];

--- a/libsandbox/libsandbox.c
+++ b/libsandbox/libsandbox.c
@@ -343,7 +343,7 @@ static char *resolve_path(const char *path, int follow_link)
 
 char *egetcwd(char *buf, size_t size)
 {
-	struct stat64 st;
+	struct stat st;
 	char *tmpbuf;
 
 	/* We can't let the C lib allocate memory for us since we have our
@@ -386,7 +386,7 @@ char *egetcwd(char *buf, size_t size)
 	 */
 	if ((tmpbuf) && (errno == 0)) {
 		save_errno();
-		if (!lstat64(buf, &st))
+		if (!lstat(buf, &st))
 			/* errno is set only on failure */
 			errno = 0;
 
@@ -445,12 +445,12 @@ void __sb_dump_backtrace(void)
 static bool write_logfile(const char *logfile, const char *func, const char *path,
                           const char *apath, const char *rpath, bool access)
 {
-	struct stat64 log_stat;
+	struct stat log_stat;
 	int stat_ret;
 	int logfd;
 	bool ret = false;
 
-	stat_ret = lstat64(logfile, &log_stat);
+	stat_ret = lstat(logfile, &log_stat);
 	/* Do not care about failure */
 	errno = 0;
 	if (stat_ret == 0 && S_ISREG(log_stat.st_mode) == 0)

--- a/libsandbox/local.mk
+++ b/libsandbox/local.mk
@@ -1,7 +1,24 @@
+noinst_LTLIBRARIES += %D%/libwrappers.la
+
+%C%_libwrappers_la_CFLAGS = $(CFLAG_EXCEPTIONS)
+
+%C%_libwrappers_la_CPPFLAGS = \
+	$(AM_CPPFLAGS) \
+	-I%D% \
+	-I$(top_srcdir)/%D% \
+	-I$(top_srcdir)/libsbutil \
+	-I$(top_srcdir)/libsbutil/include
+
+%C%_libwrappers_la_SOURCES = \
+	%D%/libsandbox.h \
+	%D%/wrappers.h   \
+	%D%/wrappers.c
+
 lib_LTLIBRARIES += %D%/libsandbox.la
 
 %C%_libsandbox_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
+	-D_FILE_OFFSET_BITS=64 \
 	-I%D% \
 	-I$(top_srcdir)/%D% \
 	-I$(top_srcdir)/libsbutil \
@@ -14,8 +31,9 @@ lib_LTLIBRARIES += %D%/libsandbox.la
 libsbutil/.libs/libsbutil.a: libsbutil/libsbutil.la
 %C%_libsandbox_la_LIBSBLIB = libsbutil/.libs/libsbutil.a
 %C%_libsandbox_la_LIBADD = \
-	-lc $(LIBDL) \
-	$(%C%_libsandbox_la_LIBSBLIB)
+	%D%/libwrappers.la \
+	$(%C%_libsandbox_la_LIBSBLIB) \
+	$(LIBDL)
 # Do not add -nostdlib or -nostartfiles, as then our constructor
 # and destructor will not be executed ...
 %C%_libsandbox_la_LDFLAGS = \
@@ -34,7 +52,6 @@ libsbutil/.libs/libsbutil.a: libsbutil/libsbutil.la
 	%D%/pre_check_unlinkat.c \
 	%D%/trace.c      \
 	%D%/wrappers.h   \
-	%D%/wrappers.c   \
 	%D%/canonicalize.c
 
 install-exec-hook:

--- a/libsandbox/pre_check_mkdirat.c
+++ b/libsandbox/pre_check_mkdirat.c
@@ -36,8 +36,8 @@ bool sb_mkdirat_pre_check(const char *func, const char *pathname, int dirfd)
 	 * not want to pass this attempt up to the higher levels as those
 	 * will trigger a sandbox violation.
 	 */
-	struct stat64 st;
-	if (0 == lstat64(canonic, &st)) {
+	struct stat st;
+	if (0 == lstat(canonic, &st)) {
 		int new_errno;
 		sb_debug_dyn("EARLY FAIL: %s(%s[%s]) @ lstat: %s\n",
 			func, pathname, canonic, strerror(errno));
@@ -47,7 +47,7 @@ bool sb_mkdirat_pre_check(const char *func, const char *pathname, int dirfd)
 		/* Hmm, is this a broken symlink we're trying to extend ?
 		 * Or is this a path like "foo/.." ?
 		 */
-		if (stat64(pathname, &st) != 0) {
+		if (stat(pathname, &st) != 0) {
 			/* XXX: This awful hack should probably be turned into a
 			 * common func that does a better job.  For now, we have
 			 * enough crap to catch gnulib tests #297026.

--- a/libsbutil/include/rcscripts/util/file.h
+++ b/libsbutil/include/rcscripts/util/file.h
@@ -23,7 +23,7 @@ bool rc_is_dir (const char *pathname, bool follow_link);
 /* The following functions do not care about errors - it only returns
  * the size/mtime of 'pathname' if it exists, and is the type requested,
  * or else 0. */
-off64_t rc_get_size (const char *pathname, bool follow_link);
+int64_t rc_get_size (const char *pathname, bool follow_link);
 
 /* The following return a pointer on success, or NULL with errno set on error.
  * If it returned NULL, but errno is not set, then there was no error, but

--- a/libsbutil/local.mk
+++ b/libsbutil/local.mk
@@ -2,6 +2,7 @@ noinst_LTLIBRARIES += %D%/libsbutil.la
 
 %C%_libsbutil_la_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
+	-D_FILE_OFFSET_BITS=64 \
 	-I$(top_srcdir)/%D% \
 	-I$(top_srcdir)/%D%/include
 %C%_libsbutil_la_LDFLAGS = -no-undefined

--- a/libsbutil/sb_close.c
+++ b/libsbutil/sb_close.c
@@ -34,7 +34,7 @@ int sb_close(int fd)
 void sb_close_all_fds(void)
 {
 	DIR *dirp;
-	struct dirent64 *de;
+	struct dirent *de;
 	int dfd, fd;
 	const char *fd_dir = sb_get_fd_dir();
 
@@ -43,7 +43,7 @@ void sb_close_all_fds(void)
 		sb_ebort("could not process %s\n", fd_dir);
 	dfd = dirfd(dirp);
 
-	while ((de = readdir64(dirp)) != NULL) {
+	while ((de = readdir(dirp)) != NULL) {
 		if (de->d_name[0] == '.')
 			continue;
 		fd = atoi(de->d_name);

--- a/libsbutil/sb_exists.c
+++ b/libsbutil/sb_exists.c
@@ -9,7 +9,7 @@
 /* Wrapper for faccessat to work around buggy behavior on musl */
 int sb_exists(int dirfd, const char *pathname, int flags)
 {
-	struct stat64 buf;
+	struct stat buf;
 
 	if (sbio_faccessat(dirfd, pathname, F_OK, flags|AT_EACCESS) == 0)
 		return 0;
@@ -20,5 +20,5 @@ int sb_exists(int dirfd, const char *pathname, int flags)
 	if (errno != EINVAL)
 		return -1;
 
-	return fstatat64(dirfd, pathname, &buf, flags);
+	return fstatat(dirfd, pathname, &buf, flags);
 }

--- a/libsbutil/src/file.c
+++ b/libsbutil/src/file.c
@@ -21,62 +21,53 @@ rc_file_exists (const char *pathname)
 bool
 rc_is_file (const char *pathname, bool follow_link)
 {
-  struct stat64 buf;
-  int retval;
+  struct stat buf;
+  int r;
 
   if (!check_str (pathname))
     return false;
 
-  retval = follow_link ? stat64 (pathname, &buf) : lstat64 (pathname, &buf);
-  if ((-1 != retval) && (S_ISREG (buf.st_mode)))
-    retval = true;
-  else
-    retval = false;
-
-  return retval;
+  r = follow_link ? stat (pathname, &buf) : lstat (pathname, &buf);
+  if (r == -1)
+	  return false;
+  return (S_ISREG (buf.st_mode));
 }
 
 bool
 rc_is_dir (const char *pathname, bool follow_link)
 {
-  struct stat64 buf;
-  int retval;
+  struct stat buf;
+  int r;
 
   if (!check_str (pathname))
     return false;
 
-  retval = follow_link ? stat64 (pathname, &buf) : lstat64 (pathname, &buf);
-  if ((-1 != retval) && (S_ISDIR (buf.st_mode)))
-    retval = true;
-  else
-    retval = false;
-
-  return retval;
+  r = follow_link ? stat (pathname, &buf) : lstat (pathname, &buf);
+  if (r == -1)
+	  return false;
+  return (S_ISDIR (buf.st_mode));
 }
 
-off64_t
+int64_t
 rc_get_size (const char *pathname, bool follow_link)
 {
-  struct stat64 buf;
-  int retval;
+  struct stat buf;
+  int r;
 
   if (!check_str (pathname))
     return 0;
 
-  retval = follow_link ? stat64 (pathname, &buf) : lstat64 (pathname, &buf);
-  if (-1 != retval)
-    retval = buf.st_size;
-  else
-    retval = 0;
-
-  return retval;
+  r = follow_link ? stat (pathname, &buf) : lstat (pathname, &buf);
+  if (r == -1)
+	  return 0;
+  return buf.st_size;
 }
 
 char **
 rc_ls_dir (const char *pathname, bool hidden, bool sort)
 {
   DIR *dp;
-  struct dirent64 *dir_entry;
+  struct dirent *dir_entry;
   char **dirlist = NULL;
 
   if (!check_arg_str (pathname))
@@ -102,7 +93,7 @@ rc_ls_dir (const char *pathname, bool hidden, bool sort)
     {
       /* Clear errno to distinguish between EOF and error */
       errno = 0;
-      dir_entry = readdir64 (dp);
+      dir_entry = readdir (dp);
       /* Only an error if 'errno' != 0, else EOF */
       if ((NULL == dir_entry) && (0 != errno))
 	{
@@ -184,10 +175,10 @@ error:
 int
 rc_file_map (const char *filename, char **buf, size_t * bufsize)
 {
-  struct stat64 stats;
+  struct stat stats;
   int fd;
 
-  fd = open64 (filename, O_RDONLY);
+  fd = open (filename, O_RDONLY);
   if (fd < 0)
     {
       rc_errno_set (errno);
@@ -195,7 +186,7 @@ rc_file_map (const char *filename, char **buf, size_t * bufsize)
       return -1;
     }
 
-  if (fstat64 (fd, &stats) < 0)
+  if (fstat (fd, &stats) < 0)
     {
       rc_errno_set (errno);
       DBG_MSG ("Failed to stat file!\n");

--- a/src/local.mk
+++ b/src/local.mk
@@ -2,6 +2,7 @@ bin_PROGRAMS += %D%/sandbox
 
 %C%_sandbox_CPPFLAGS = \
 	$(AM_CPPFLAGS) \
+	-D_FILE_OFFSET_BITS=64 \
 	-I$(top_srcdir)/libsbutil \
 	-I$(top_srcdir)/libsbutil/include
 

--- a/src/namespaces.c
+++ b/src/namespaces.c
@@ -28,7 +28,7 @@
 
 #define xfopen(path, ...) \
 ({ \
-	FILE *_ret = fopen64(path, __VA_ARGS__); \
+	FILE *_ret = fopen(path, __VA_ARGS__); \
 	if (_ret == 0) \
 		sb_perr("fopen(%s) failed", #path); \
 	_ret; \
@@ -107,7 +107,7 @@ static void ns_mount_setup(void)
 	/* Now map in all the files/dirs we do want to expose. */
 	int fd;
 #define bind_file(node) \
-	fd = open64("/dev/shm/" node, O_CREAT, 0); \
+	fd = open("/dev/shm/" node, O_CREAT, 0); \
 	sb_assert(fd != -1); \
 	close(fd); \
 	xmount("/dev/" node, "/dev/shm/" node, NULL, MS_BIND, NULL)

--- a/tests/get-group.c
+++ b/tests/get-group.c
@@ -31,8 +31,8 @@ int main(int argc, char *argv[])
 				printf("%i\n", grp->gr_gid);
 			} else {
 				const char *file = argv[1];
-				struct stat64 st;
-				if (lstat64(file, &st))
+				struct stat st;
+				if (lstat(file, &st))
 					errp("lstat(%s) failed", file);
 				printf("%i\n", st.st_gid);
 			}

--- a/tests/get-user.c
+++ b/tests/get-user.c
@@ -31,8 +31,8 @@ int main(int argc, char *argv[])
 				printf("%i\n", pwd->pw_uid);
 			} else {
 				const char *file = argv[1];
-				struct stat64 st;
-				if (lstat64(file, &st))
+				struct stat st;
+				if (lstat(file, &st))
 					errp("lstat(%s) failed", file);
 				printf("%i\n", st.st_uid);
 			}

--- a/tests/local.mk
+++ b/tests/local.mk
@@ -110,6 +110,9 @@ dist_check_SCRIPTS += \
 # This will be used by all programs, not just tests/ ...
 AM_LDFLAGS = `expr $@ : .*_static >/dev/null && echo -all-static`
 
+%C%_get_group_CPPFLAGS = -D_FILE_OFFSET_BITS=64
+%C%_get_user_CPPFLAGS = -D_FILE_OFFSET_BITS=64
+
 %C%_sb_printf_tst_CFLAGS = -I$(top_srcdir)/libsbutil -I$(top_srcdir)/libsbutil/include
 %C%_sb_printf_tst_LDADD = libsbutil/libsbutil.la
 

--- a/tests/test-skel-0.c
+++ b/tests/test-skel-0.c
@@ -129,7 +129,7 @@ int at_get_fd(const char *str_dirfd)
 	}
 	str_mode = strtok(NULL, ":");
 
-	return open64(str_path, f_get_flags(str_flags), sscanf_mode_t(str_mode));
+	return open(str_path, f_get_flags(str_flags), sscanf_mode_t(str_mode));
 }
 
 #define V_TIMESPEC "NULL | NOW | #[,#]"

--- a/tests/trace-memory_static_tst.c
+++ b/tests/trace-memory_static_tst.c
@@ -26,7 +26,7 @@ volatile uintptr_t offset = 0;
 #define check_ptr(addr) \
 ({ \
 	printf("  open(%p)\n", addr); \
-	ret = open64(non_const_ptr(addr), O_RDONLY); \
+	ret = open(non_const_ptr(addr), O_RDONLY); \
 	assert(ret == -1 && errno == EFAULT); \
 })
 


### PR DESCRIPTION
Define _FILE_OFFSET_BITS=64 for code that does not directly affect the wrapper functions. This includes all of libsbutil, src, and most of libsandbox. Replace xxx64 calls with the unsuffixed versions.

Split the wrapper code into its own convenience library and build it without _FILE_OFFSET_BITS set. Link this into libsandbox.

Also build the tests without _FILE_OFFSET_BITS set so we can actually test the legacy functions.

The rc_get_size function now returns int64_t instead of off64_t. There should be no effective change in behavior.

Bug: https://bugs.gentoo.org/908801