### PR TITLE
etc/sandbox.conf: allow SELinux writes

### DIFF
--- a/etc/sandbox.conf
+++ b/etc/sandbox.conf
@@ -102,4 +102,7 @@ SANDBOX_WRITE="/dev/ptmx:/dev/pts/:/dev/shm"
 SANDBOX_WRITE="/tmp/:/var/tmp/:/usr/tmp/"
 # Needed for shells
 SANDBOX_WRITE="${HOME}/.bash_history"
-
+# SELinux-aware programs write to entries here
+SANDBOX_WRITE="/selinux/:/sys/fs/selinux/"
+# for setfscreatecon
+SANDBOX_WRITE="/proc/self/"


### PR DESCRIPTION
When cross-compiling on a SELinux system where the profile has not yet been set for the target (i.e. embedded profile) or where a non-SELinux profile has been selected, writes to /proc/thread-self/attr/fscreate will be prevented by the sandbox:

```
>>> Completed installing sys-libs/timezone-data-2026b into /usr/alpha-unknown-linux-gnu/tmp/portage/sys-libs/timezone-data-2026b/image

* Final size of build directory: 9820 KiB (9.5 MiB)
* Final size of installed tree:  2720 KiB (2.6 MiB)

* ACCESS DENIED:  open_wr:            /proc/thread-self/attr/fscreate
sed: warning: failed to set default file creation context to staff_u:object_r:usr_t:s0: Permission denied
* ACCESS DENIED:  open_wr:            /proc/thread-self/attr/fscreate
strip: alpha-unknown-linux-gnu-strip --strip-unneeded -N __gentoo_check_ldflags__ -R .comment -R .GCC.command.line -R .note.gnu.gold-version
    /usr/bin/zdump
```

Allow writes to /selinux, /sys/fs/selinux, and /proc/self.

The entries allowing these normally come from the SELinux profile which doesn't help if Portage is using another profile for cross. There's no need to keep these conditional on SELinux, as they're harmless otherwise.

I've kept /selinux as well for now even though it is obsolete as the userland still supports it, and it seems to make sense to clean all of that up at once. For /proc/self, we sometimes get bug reports for harmless cases of this being used too.

Closes: https://bugs.gentoo.org/976051